### PR TITLE
Fix deploy workflow bundle install failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,8 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
-          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
       - name: Build with Jekyll
         run: bundle exec jekyll build
         env:


### PR DESCRIPTION
## Summary

- Replaces `bundler-cache: true` in `ruby/setup-ruby` with an explicit `bundle install` step
- Root cause: `actions/configure-pages` sets `GITHUB_PAGES=true` in the environment, which causes `setup-ruby`'s gemfile detection to silently fail — bundle install is skipped, and the subsequent `bundle exec jekyll build` errors with "Could not locate Gemfile"

## Test plan

- [ ] Merge and confirm the Actions workflow runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)