### PR TITLE
Move configure-pages after Jekyll build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
@@ -31,6 +30,7 @@ jobs:
         run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
+      - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
 
   deploy:


### PR DESCRIPTION
## Summary

- Moves `actions/configure-pages` to after `bundle install` and `jekyll build`, just before `upload-pages-artifact`
- Root cause: `configure-pages` exports `GITHUB_PAGES=true` into `$GITHUB_ENV`, which persists to all subsequent steps and causes bundler to fail with "Could not locate Gemfile" — it appears to override bundler's normal Gemfile detection when that var is set
- `configure-pages` doesn't need to run before the build since its outputs (`base_url` etc.) aren't referenced in the build command; it only needs to run before the artifact upload for Pages auth

## Test plan

- [ ] Merge and confirm the Actions workflow runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)