### PR TITLE
Debug: diagnose bundle install failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,11 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
+      - name: Debug environment
+        run: |
+          pwd
+          ls -la
+          env | grep -i bundle || true
       - name: Install dependencies
         run: bundle install
       - name: Build with Jekyll


### PR DESCRIPTION
Temporary debug step — adds pwd/ls/env output before bundle install to identify why bundler cannot locate the Gemfile on the runner. Will remove once root cause is confirmed.