### PR TITLE
Track Gemfile and remove debug step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,11 +24,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
-      - name: Debug environment
-        run: |
-          pwd
-          ls -la
-          env | grep -i bundle || true
       - name: Install dependencies
         run: bundle install
       - name: Build with Jekyll

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@ _site
 .sass-cache
 .jekyll-metadata
 **/.DS_Store
-Gemfile
-Gemfile.lock
 **/._*
 sources
 .vscode

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins


### PR DESCRIPTION
## Summary

- Root cause found: `Gemfile` and `Gemfile.lock` were listed in `.gitignore` and had never been committed — the runner checked out the repo with no Gemfile present, causing every `bundle install` attempt to fail with "Could not locate Gemfile" (exit 10)
- Removes both from `.gitignore` and commits the `Gemfile`
- Leaves `Gemfile.lock` untracked so the runner generates a fresh one compatible with its platform and bundler version (the existing lock was generated with Bundler 1.15.4 and would likely cause platform conflicts)
- Removes the temporary debug step added in PR #28

## Test plan

- [ ] Merge and confirm the Actions workflow runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)