### PR TITLE
Unpin Decap CMS version to fix PKCE auth

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -7,6 +7,6 @@
   <title>Content Manager</title>
 </head>
 <body>
-  <script src="https://unpkg.com/decap-cms@3.12.2/dist/decap-cms.js"></script>
+  <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- `decap-cms@3.12.2` has a bug where `auth_type: pkce` silently falls back to Netlify auth instead of initializing the PKCE client — confirmed by no console errors but GitHub OAuth redirecting to `api.netlify.com` instead of `github.com`
- Switching to `@^3.0.0` to pull the latest stable 3.x release

## Test plan

- [ ] Merge and wait for Actions deploy
- [ ] Open `https://craigmcn.ca/admin/` — clicking "Login with Github" should open `github.com/login/oauth/authorize` (not `api.netlify.com`)
- [ ] Complete OAuth flow and confirm CMS loads with post list

🤖 Generated with [Claude Code](https://claude.com/claude-code)