### PR TITLE
Use CMS.init() to bypass config.yml load (PKCE debug)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -7,6 +7,40 @@
   <title>Content Manager</title>
 </head>
 <body>
+  <script>window.CMS_MANUAL_INIT = true;</script>
   <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+  <script>
+    CMS.init({
+      config: {
+        backend: {
+          name: 'github',
+          repo: 'craigmcn/craigmcn.github.io',
+          branch: 'main',
+          auth_type: 'pkce',
+          app_id: 'Ov23lidKMfqod2ZIuGyX',
+        },
+        media_folder: 'images/uploads',
+        public_folder: '/images/uploads',
+        collections: [
+          {
+            name: 'posts',
+            label: 'Posts',
+            folder: '_posts',
+            create: true,
+            slug: '{{year}}-{{month}}-{{day}}-{{slug}}',
+            fields: [
+              { label: 'Title', name: 'title', widget: 'string' },
+              { label: 'Date', name: 'date', widget: 'datetime', date_format: 'YYYY-MM-DD', time_format: 'HH:mm:ssZ', format: 'YYYY-MM-DDTHH:mm:ssZ' },
+              { label: 'Excerpt', name: 'excerpt', widget: 'text' },
+              { label: 'Layout', name: 'layout', widget: 'hidden', default: 'post' },
+              { label: 'Categories', name: 'categories', widget: 'list' },
+              { label: 'Tags', name: 'tags', widget: 'list' },
+              { label: 'Body', name: 'body', widget: 'markdown' },
+            ],
+          },
+        ],
+      },
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- `auth_type: pkce` was silently falling back to Netlify auth despite the config loading without errors
- Switches from auto-init via `admin/config.yml` to `CMS.init()` with inline config to rule out a Decap CMS bug in YAML config parsing
- If PKCE works after this change, the bug is in how 3.12.2 loads the external config file; if not, PKCE itself is broken in this version and we'll need a different approach

## Test plan

- [ ] Merge and wait for Actions deploy
- [ ] Open `https://craigmcn.ca/admin/` — "Login with Github" should go to `github.com` not `api.netlify.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)