### PR TITLE
Switch from Decap CMS to Sveltia CMS

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -7,40 +7,6 @@
   <title>Content Manager</title>
 </head>
 <body>
-  <script>window.CMS_MANUAL_INIT = true;</script>
-  <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
-  <script>
-    CMS.init({
-      config: {
-        backend: {
-          name: 'github',
-          repo: 'craigmcn/craigmcn.github.io',
-          branch: 'main',
-          auth_type: 'pkce',
-          app_id: 'Ov23lidKMfqod2ZIuGyX',
-        },
-        media_folder: 'images/uploads',
-        public_folder: '/images/uploads',
-        collections: [
-          {
-            name: 'posts',
-            label: 'Posts',
-            folder: '_posts',
-            create: true,
-            slug: '{{year}}-{{month}}-{{day}}-{{slug}}',
-            fields: [
-              { label: 'Title', name: 'title', widget: 'string' },
-              { label: 'Date', name: 'date', widget: 'datetime', date_format: 'YYYY-MM-DD', time_format: 'HH:mm:ssZ', format: 'YYYY-MM-DDTHH:mm:ssZ' },
-              { label: 'Excerpt', name: 'excerpt', widget: 'text' },
-              { label: 'Layout', name: 'layout', widget: 'hidden', default: 'post' },
-              { label: 'Categories', name: 'categories', widget: 'list' },
-              { label: 'Tags', name: 'tags', widget: 'list' },
-              { label: 'Body', name: 'body', widget: 'markdown' },
-            ],
-          },
-        ],
-      },
-    });
-  </script>
+  <script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Decap CMS 3.12.2 silently ignores `auth_type: pkce`, falling back to Netlify auth (confirmed via console — no errors, but login opens `api.netlify.com` instead of `github.com`)
- Sveltia CMS is a drop-in replacement with working GitHub PKCE support
- Only `admin/index.html` changes (Sveltia's ES module script tag); `admin/config.yml` is unchanged

## Test plan

- [ ] Merge and wait for Actions deploy
- [ ] Open `https://craigmcn.ca/admin/` — "Login with Github" should redirect to `github.com/login/oauth/authorize`
- [ ] Complete OAuth and confirm CMS loads with the post list

🤖 Generated with [Claude Code](https://claude.com/claude-code)