### PR TITLE
Switch to Cloudflare Worker OAuth proxy for CMS auth

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,8 +2,7 @@ backend:
   name: github
   repo: craigmcn/craigmcn.github.io
   branch: main
-  auth_type: pkce
-  app_id: Ov23lidKMfqod2ZIuGyX
+  base_url: https://quiet-sunset-3f55.craig-040.workers.dev
 
 media_folder: "images/uploads"
 public_folder: "/images/uploads"

--- a/admin/index.html
+++ b/admin/index.html
@@ -7,41 +7,6 @@
   <title>Content Manager</title>
 </head>
 <body>
-  <script>window.CMS_MANUAL_INIT = true;</script>
   <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
-  <script>
-    CMS.init({
-      config: {
-        load_config_file: false,
-        backend: {
-          name: 'github',
-          repo: 'craigmcn/craigmcn.github.io',
-          branch: 'main',
-          auth_type: 'pkce',
-          app_id: 'Ov23lidKMfqod2ZIuGyX',
-        },
-        media_folder: 'images/uploads',
-        public_folder: '/images/uploads',
-        collections: [
-          {
-            name: 'posts',
-            label: 'Posts',
-            folder: '_posts',
-            create: true,
-            slug: '{{year}}-{{month}}-{{day}}-{{slug}}',
-            fields: [
-              { label: 'Title', name: 'title', widget: 'string' },
-              { label: 'Date', name: 'date', widget: 'datetime', date_format: 'YYYY-MM-DD', time_format: 'HH:mm:ssZ', format: 'YYYY-MM-DDTHH:mm:ssZ' },
-              { label: 'Excerpt', name: 'excerpt', widget: 'text' },
-              { label: 'Layout', name: 'layout', widget: 'hidden', default: 'post' },
-              { label: 'Categories', name: 'categories', widget: 'list' },
-              { label: 'Tags', name: 'tags', widget: 'list' },
-              { label: 'Body', name: 'body', widget: 'markdown' },
-            ],
-          },
-        ],
-      },
-    });
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- PKCE is not reliably supported in Decap CMS 3.x — `auth_type: pkce` silently falls back to Netlify auth
- Deploys a Cloudflare Worker (`quiet-sunset-3f55.craig-040.workers.dev`) that handles the GitHub OAuth token exchange server-side
- `admin/config.yml`: removes `auth_type`/`app_id`, adds `base_url` pointing to the Worker
- `admin/index.html`: reverts to simple auto-init (no `CMS_MANUAL_INIT` scaffolding)
- GitHub OAuth App callback URL must be updated to `https://quiet-sunset-3f55.craig-040.workers.dev/callback`

## Test plan

- [ ] Merge and wait for Actions deploy
- [ ] Open `https://craigmcn.ca/admin/` — "Login with Github" popup should open to `github.com`
- [ ] Authenticate and confirm the CMS post list loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)